### PR TITLE
ZK-93: Journal Child Entry Tagging

### DIFF
--- a/web/src/components/form/ChildJournalEntryForm.tsx
+++ b/web/src/components/form/ChildJournalEntryForm.tsx
@@ -18,28 +18,20 @@ export default function ChildJournalEntryForm() {
     const [childEntryTaggingIndex, setChildEntryTaggingIndex] = useState<number>(-1)
     const [childEntryTaggingAnchorEl, setChildEntryTaggingAnchorEl] = useState<HTMLElement | null>(null)
     
-    const { control, setValue } = useFormContext<JournalEntry>()
+    const { control, setValue, watch } = useFormContext<JournalEntry>()
     const children = useWatch({ control, name: 'children' }) ?? []
     const childEntriesFieldArray = useFieldArray({
         control,
         name: 'children',
     })
 
-	const handleAddChildEntry = useCallback(() => {
-		if (!journalContext.journal) {
-			return
-		}
-		const newEntry: JournalEntry = makeJournalEntry({}, journalContext.journal._id)
+    const handleAddChildEntry = useCallback(() => {
+        if (!journalContext.journal) {
+            return
+        }
+        const newEntry: JournalEntry = makeJournalEntry({}, journalContext.journal._id)
         childEntriesFieldArray.prepend(newEntry)
-	}, [children])
-    
-    // const handleToggleFlagged = (index: number, isFlagged: boolean) => {
-    //     const entry = childEntriesFieldArray.fields[index]
-    //     const tagIds = isFlagged
-    //         ? [...entry.tagIds ?? [], RESERVED_TAGS.FLAGGED._id]
-    //         : entry.tagIds?.filter((tagId) => tagId !== RESERVED_TAGS.FLAGGED._id)
-    //     childEntriesFieldArray.update(index, { ...entry, tagIds })
-    // }
+    }, [children])
 
     const handleToggleSelected = (key: string) => {
         const isSelected = selectedRows.includes(key)
@@ -88,7 +80,10 @@ export default function ChildJournalEntryForm() {
             <EntryTagPicker
                 open={Boolean(childEntryTaggingAnchorEl)}
                 anchorEl={childEntryTaggingAnchorEl}
-                onClose={() => setChildEntryTaggingAnchorEl(null)}
+                onClose={() => {
+                    setChildEntryTaggingAnchorEl(null)
+                    setChildEntryTaggingIndex(-1)
+                }}
                 value={(childEntryTaggingIndex >= 0 && children[childEntryTaggingIndex])
                     ? children[childEntryTaggingIndex].tagIds
                     : undefined
@@ -112,8 +107,10 @@ export default function ChildJournalEntryForm() {
             )}
             <Stack mt={2} mx={-1} gap={2}>
                 {childEntriesFieldArray.fields.map((entry, index) => {
-                    const isTagged = Boolean(entry.tagIds?.length)
+                    const childTags = watch(`children.${index}.tagIds`) ?? []
+                    const isTagged = childTags.length > 0
                     const hasMemo = journalEntriesWithMemos.includes(entry._id) || Boolean(entry.memo)
+                    
                     return (
                         <Stack direction='row' alignItems={'flex-start'} sx={{ width: '100%' }} key={entry._id}>
                             <Checkbox

--- a/web/src/components/form/JournalEntryForm.tsx
+++ b/web/src/components/form/JournalEntryForm.tsx
@@ -40,14 +40,6 @@ export default function JournalEntryForm() {
 
 	return (
 		<>
-			{/* <EntryTagPicker
-				anchorEl={entryTagPickerData.anchorEl}
-				onClose={() => setEntryTagPickerData((prev) => ({ ...prev, anchorEl: null }))}
-				value={entryTagPickerSelectedTags}
-				onChange={(tagIds: EntryTag['_id'][]) => {
-					setValue(`children.${entryTagPickerData.index}.tagIds`, tagIds)
-				}}
-			/> */}
 			<Box sx={{ position: 'relative' /* Used for attachment drag overlay */ }}>
 				<Grid container columns={12} spacing={4} rowSpacing={2} mb={1} sx={{ px: 0 }}>
 					<Grid size={12}>

--- a/web/src/components/input/EntryTagAutocomplete.tsx
+++ b/web/src/components/input/EntryTagAutocomplete.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Autocomplete, AutocompleteProps, ListItem, ListItemText, TextField } from '@mui/material'
+import { Close, Done } from "@mui/icons-material";
 
 import { useContext } from 'react'
 import { JournalContext } from '@/contexts/JournalContext'
@@ -26,15 +27,34 @@ export default function EntryTagAutocomplete(props: EntryTagAutocompleteProps) {
 			options={[...Object.keys(RESERVED_TAGS), ...Object.keys(data)]}
 			renderInput={(params) => <TextField {...params} label={'Tag'} />}
 			getOptionLabel={(option) => options[option]?.label}
-			renderOption={(props, option) => {
+			renderOption={(props, option, { selected }) => {
 				const { key, ...optionProps } = props
-				const entryTag: EntryTag | ReservedTag = options[option]
+				const entryTag: EntryTag | ReservedTag | undefined = options[option]
 
 				return (
-					<ListItem dense key={key} {...optionProps}>
-						<ListItemText primary={entryTag?.label} secondary={entryTag?.description} />
+					<ListItem key={key} {...optionProps}>
+						<Done
+							sx={(theme) => ({
+								width: 17,
+								height: 17,
+								mr: theme.spacing(1),
+								visibility: selected ? 'visible' : 'hidden',
+							})}
+						/>
+						<ListItemText
+							primary={entryTag?.label}
+							secondary={entryTag?.description}
+						/>
+						<Close
+							sx={{
+								opacity: 0.6,
+								width: 18,
+								height: 18,
+								visibility: selected ? 'visible' : 'hidden',
+							}}
+						/>
 					</ListItem>
-				)
+				);
 			}}
 			{...rest}
 			multiple

--- a/web/src/components/input/EntryTagSelector.tsx
+++ b/web/src/components/input/EntryTagSelector.tsx
@@ -11,7 +11,6 @@ import {
 import { Settings } from "@mui/icons-material";
 import { EntryTag, ReservedTag } from "@/types/schema";
 import { JournalContext } from "@/contexts/JournalContext";
-import { createEntryTag } from "@/database/actions";
 import clsx from "clsx";
 import { EntryTagAutocompleteProps } from "./EntryTagAutocomplete";
 import { RESERVED_TAGS } from "@/constants/tags";
@@ -23,7 +22,7 @@ export default function EntryTagSelector(props: EntryTagSelectorProps) {
     const anchorRef = useRef<HTMLAnchorElement>(null);
     const [open, setOpen] = useState<boolean>(false)
     
-    const { getEntryTagsQuery, journal } = useContext(JournalContext)
+    const { getEntryTagsQuery } = useContext(JournalContext)
     const value = props.value ?? []
 
     const options: Record<string, EntryTag | ReservedTag> = {
@@ -37,18 +36,6 @@ export default function EntryTagSelector(props: EntryTagSelectorProps) {
 
     const handleClose = () => {
         setOpen(false)
-    }
-
-    const handleCreateEntryTagWithValue = async (value: string) => {
-        if (!journal) {
-            return
-        }
-        const journalId = journal._id
-        await createEntryTag({
-            label: value,
-            description: '',
-        }, journalId)
-        getEntryTagsQuery.refetch()
     }
 
     return (
@@ -100,7 +87,6 @@ export default function EntryTagSelector(props: EntryTagSelectorProps) {
                 {...props}
                 open={open}
                 anchorEl={anchorRef.current}
-                onCreateEntryTagWithValue={handleCreateEntryTagWithValue}
                 onClose={() => handleClose()}
             />
         </Stack>

--- a/web/src/components/input/EntryTagSelector.tsx
+++ b/web/src/components/input/EntryTagSelector.tsx
@@ -1,35 +1,28 @@
 import { useContext, useRef, useState } from "react";
 import { 
-    AutocompleteCloseReason,
     Button,
     ButtonBase,
     Chip,
-    ClickAwayListener,
-    Divider,
     IconButton,
-    InputBase,
     Link,
-    ListItem,
-    ListItemText,
-    Paper,
-    Popper,
     Stack,
     Typography
 } from "@mui/material";
-import { Close, Done, Settings } from "@mui/icons-material";
+import { Settings } from "@mui/icons-material";
 import { EntryTag, ReservedTag } from "@/types/schema";
 import { JournalContext } from "@/contexts/JournalContext";
 import { createEntryTag } from "@/database/actions";
 import clsx from "clsx";
-import EntryTagAutocomplete, { EntryTagAutocompleteProps } from "./EntryTagAutocomplete";
+import { EntryTagAutocompleteProps } from "./EntryTagAutocomplete";
 import { RESERVED_TAGS } from "@/constants/tags";
+import { EntryTagPicker } from "../pickers/EntryTagPicker";
 
 type EntryTagSelectorProps = Omit<EntryTagAutocompleteProps, 'renderInput'>
 
 export default function EntryTagSelector(props: EntryTagSelectorProps) {
     const anchorRef = useRef<HTMLAnchorElement>(null);
     const [open, setOpen] = useState<boolean>(false)
-    const [searchValue, setSearchValue] = useState<string>('')
+    
     const { getEntryTagsQuery, journal } = useContext(JournalContext)
     const value = props.value ?? []
 
@@ -46,13 +39,13 @@ export default function EntryTagSelector(props: EntryTagSelectorProps) {
         setOpen(false)
     }
 
-    const createEntryTagWithValue = async () => {
+    const handleCreateEntryTagWithValue = async (value: string) => {
         if (!journal) {
             return
         }
         const journalId = journal._id
         await createEntryTag({
-            label: searchValue,
+            label: value,
             description: '',
         }, journalId)
         getEntryTagsQuery.refetch()
@@ -103,89 +96,13 @@ export default function EntryTagSelector(props: EntryTagSelectorProps) {
                     })}
                 </Stack>
             )}
-            <Popper
+            <EntryTagPicker
+                {...props}
                 open={open}
                 anchorEl={anchorRef.current}
-                sx={(theme) => ({ width: '300px', zIndex: theme.zIndex.modal})}
-                placement='bottom-start'
-            >
-                <ClickAwayListener onClickAway={handleClose}>
-                    <Paper>
-                        <EntryTagAutocomplete
-                            {...props}
-                            open
-                            onClose={(
-                                _event,
-                                reason: AutocompleteCloseReason,
-                            ) => {
-                                if (reason === 'escape') {
-                                    handleClose();
-                                }
-                            }}
-                            disableCloseOnSelect
-                            noOptionsText={
-                                searchValue.length === 0 ? (
-                                    <Typography variant='body2' color='textSecondary'>
-                                        No tags
-                                    </Typography>
-                                ) : (
-                                    <Link onClick={() => createEntryTagWithValue()}>
-                                        Create new tag &quot;{searchValue}&quot;
-                                    </Link>
-                                )
-                            }
-                            renderTags={() => null}
-                            renderInput={(params) => (
-                                <>
-                                    <InputBase
-                                        sx={{ width: '100%', px: 2, py: 1 }}
-                                        ref={params.InputProps.ref}
-                                        value={searchValue}
-                                        onChange={(event) => setSearchValue(event.target.value)}
-                                        inputProps={params.inputProps}
-                                        autoFocus
-                                        placeholder="Filter tags"
-                                    />
-                                    <Divider />
-                                </>
-                            )}
-                            renderOption={(props, option, { selected }) => {
-                                const { key, ...optionProps } = props
-                                const entryTag: EntryTag | ReservedTag | undefined = options[option]
-
-                                return (
-                                    <ListItem key={key} {...optionProps}>
-                                        <Done
-                                            sx={(theme) => ({
-                                                width: 17,
-                                                height: 17,
-                                                mr: theme.spacing(1),
-                                                visibility: selected ? 'visible' : 'hidden',
-                                            })}
-                                        />
-                                        <ListItemText
-                                            primary={entryTag?.label}
-                                            secondary={entryTag?.description}
-                                        />
-                                        <Close
-                                            sx={{
-                                                opacity: 0.6,
-                                                width: 18,
-                                                height: 18,
-                                                visibility: selected ? 'visible' : 'hidden',
-                                            }}
-                                        />
-                                    </ListItem>
-                                );
-                            }}
-                            slots={{
-                                popper: (params: any) => <div {...params} />,
-                                paper: (params) => <div {...params} />,
-                            }}
-                        />
-                    </Paper>
-                </ClickAwayListener>
-            </Popper>
+                onCreateEntryTagWithValue={handleCreateEntryTagWithValue}
+                onClose={() => handleClose()}
+            />
         </Stack>
     )
 }

--- a/web/src/components/modal/JournalEntryModal.tsx
+++ b/web/src/components/modal/JournalEntryModal.tsx
@@ -56,6 +56,7 @@ export default function JournalEntryModal(props: EditJournalEntryModalProps) {
 	const hasTags = journalEntryHasTags(currentFormState as JournalEntry)
 	const isFlagged = journalEntryIsFlagged(currentFormState as JournalEntry)
 	const childIsFlagged = children.some(journalEntryIsFlagged)
+	const childHasTags = children.some(journalEntryHasTags)
 
 	const [debouncedhandleSaveFormWithCurrentValues, flushSaveFormDebounce] = useDebounce(handleSaveFormWithCurrentValues, 1000)
 
@@ -133,7 +134,7 @@ export default function JournalEntryModal(props: EditJournalEntryModalProps) {
 									</Tooltip>
 								</Grow>
 							)}
-							{hasTags && (
+							{(hasTags || childHasTags) && (
 								<Grow key="TAGS" in>
 									<Tooltip title='Tags applied'>
 										<LocalOffer fontSize='small' sx={{ cursor: 'pointer' }} />

--- a/web/src/components/pickers/EntryTagPicker.tsx
+++ b/web/src/components/pickers/EntryTagPicker.tsx
@@ -10,25 +10,39 @@ import {
     Typography
 } from "@mui/material";
 
-import { useState } from "react";
+import { useContext, useState } from "react";
 import EntryTagAutocomplete, { EntryTagAutocompleteProps } from "../input/EntryTagAutocomplete";
+
+import { JournalContext } from "@/contexts/JournalContext";
+import { createEntryTag } from "@/database/actions";
 
 interface EntryTagPickerProps extends Omit<EntryTagAutocompleteProps, 'renderInput'> {
 	anchorEl: HTMLElement | null
 	open: boolean
 	onClose: () => void
-	onCreateEntryTagWithValue: (value: string) => Promise<void>
 }
 
 export const EntryTagPicker = (props: EntryTagPickerProps) => {
 	const [searchValue, setSearchValue] = useState<string>('')
 
+	const { getEntryTagsQuery, journal } = useContext(JournalContext)
+
+	const handleCreateEntryTagWithValue = async (value: string) => {
+        if (!journal) {
+            return
+        }
+        const journalId = journal._id
+        await createEntryTag({
+            label: value,
+            description: '',
+        }, journalId)
+        getEntryTagsQuery.refetch()
+    }
+
 	const {
 		anchorEl,
 		open,
 		onClose,
-		onCreateEntryTagWithValue,
-		// options,
 		...rest
 	} = props
 
@@ -59,7 +73,7 @@ export const EntryTagPicker = (props: EntryTagPickerProps) => {
 									No tags
 								</Typography>
 							) : (
-								<Link onClick={() => onCreateEntryTagWithValue(searchValue)}>
+								<Link onClick={() => handleCreateEntryTagWithValue(searchValue)}>
 									Create new tag &quot;{searchValue}&quot;
 								</Link>
 							)

--- a/web/src/components/pickers/EntryTagPicker.tsx
+++ b/web/src/components/pickers/EntryTagPicker.tsx
@@ -1,77 +1,91 @@
-import { JournalContext } from '@/contexts/JournalContext'
-import { EntryTag } from '@/types/schema'
-import {
-	Box,
-	Checkbox,
-	Divider,
-	ListItemIcon,
-	ListItemText,
-	MenuItem,
-	MenuList,
-	Popover,
-	Typography,
-} from '@mui/material'
-import { useContext } from 'react'
 
-interface TransactionTagPicker {
-	anchorEl: Element | null
-	value: EntryTag['_id'][]
-	onChange: (tags: EntryTag['_id'][]) => void
+import { 
+    AutocompleteCloseReason,
+    ClickAwayListener,
+    Divider,
+    InputBase,
+    Link,
+    Paper,
+    Popper,
+    Typography
+} from "@mui/material";
+
+import { useState } from "react";
+import EntryTagAutocomplete, { EntryTagAutocompleteProps } from "../input/EntryTagAutocomplete";
+
+interface EntryTagPickerProps extends Omit<EntryTagAutocompleteProps, 'renderInput'> {
+	anchorEl: HTMLElement | null
+	open: boolean
 	onClose: () => void
+	onCreateEntryTagWithValue: (value: string) => Promise<void>
 }
 
-export default function EntryTagPicker(props: TransactionTagPicker) {
-	const { anchorEl, onClose } = props
-	const open = Boolean(anchorEl)
+export const EntryTagPicker = (props: EntryTagPickerProps) => {
+	const [searchValue, setSearchValue] = useState<string>('')
 
-	const { getEntryTagsQuery } = useContext(JournalContext)
-
-	const handleToggleTag = (tagId: EntryTag['_id']) => {
-		if (props.value.includes(tagId)) {
-			props.onChange(props.value.filter((t) => t !== tagId))
-		} else {
-			props.onChange([...props.value, tagId])
-		}
-	}
+	const {
+		anchorEl,
+		open,
+		onClose,
+		onCreateEntryTagWithValue,
+		// options,
+		...rest
+	} = props
 
 	return (
-		<Popover
-			anchorEl={anchorEl}
+		<Popper
 			open={open}
-			onClose={onClose}
-			anchorOrigin={{
-				vertical: 'bottom',
-				horizontal: 'left',
-			}}
-			transformOrigin={{
-				vertical: 'top',
-				horizontal: 'left',
-			}}>
-			<Box p={2}>
-				<Typography variant="body2">Apply tags to this record</Typography>
-			</Box>
-			<Divider />
-			<MenuList>
-				{Object.values(getEntryTagsQuery.data).map((entryTag) => {
-					const tagId = entryTag._id
-					const checked = props.value.includes(tagId)
-
-					return (
-						<MenuItem key={entryTag._id} onClick={() => handleToggleTag(tagId)}>
-							{/* {props.value.includes(tag as EntryTag) && (
-                                <ListItemIcon><Check /></ListItemIcon>
-                            )} */}
-							<ListItemIcon>
-								<Checkbox checked={checked} />
-							</ListItemIcon>
-							<ListItemText primary={entryTag.label} secondary={entryTag.description} />
-							{/* {props.value.includes(tag as EntryTag) && (
-                                <Close />
-                            )} */}
-						</MenuItem>
-					)
-				})}
-			</MenuList>
-		</Popover>
+			anchorEl={anchorEl}
+			sx={(theme) => ({ width: '300px', zIndex: theme.zIndex.modal})}
+			placement='bottom-start'
+		>
+			<ClickAwayListener onClickAway={onClose}>
+				<Paper>
+					<EntryTagAutocomplete
+						{...rest}
+						open
+						onClose={(
+							_event,
+							reason: AutocompleteCloseReason,
+						) => {
+							if (reason === 'escape') {
+								onClose();
+							}
+						}}
+						disableCloseOnSelect
+						noOptionsText={
+							searchValue.length === 0 ? (
+								<Typography variant='body2' color='textSecondary'>
+									No tags
+								</Typography>
+							) : (
+								<Link onClick={() => onCreateEntryTagWithValue(searchValue)}>
+									Create new tag &quot;{searchValue}&quot;
+								</Link>
+							)
+						}
+						renderTags={() => null}
+						renderInput={(params) => (
+							<>
+								<InputBase
+									sx={{ width: '100%', px: 2, py: 1 }}
+									ref={params.InputProps.ref}
+									value={searchValue}
+									onChange={(event) => setSearchValue(event.target.value)}
+									inputProps={params.inputProps}
+									autoFocus
+									placeholder="Filter tags"
+								/>
+								<Divider />
+							</>
+						)}
+						slots={{
+							popper: (params: any) => <div {...params} />,
+							paper: (params) => <div {...params} />,
+						}}
+					/>
+				</Paper>
+			</ClickAwayListener>
+		</Popper>
 	)
 }


### PR DESCRIPTION
Currently, users can flag a child entry, but not add tags. This was originally because the UI was too difficult to design in order to make room for the Tags auto complete.

Instead, we should replace the flag iconbutton with a tag. Clicking it opens the tags picker, and in similar fashion to the current flag iconbutton, the tag icon button will be filled if one or more tag is applied, and outlined (perhaps even slightly faded to indicate an “empty” state) if no tags are applied.

![image](https://github.com/user-attachments/assets/e510eca2-70eb-44f8-8d4e-c865853c4e77)
